### PR TITLE
fix: screen-reader-only utility & footer open source heading

### DIFF
--- a/packages/app/src/components/footer.svelte
+++ b/packages/app/src/components/footer.svelte
@@ -8,9 +8,9 @@
     <div role="presentation">
       <h2 class="open_source_heading">
         Built with Open Source
-        <span class="screen_reader_only">(</span>
+        <span class="screen_reader_only">&lpar;</span>
         <ThankYou aria-label="Thank you!" />
-        <span class="screen_reader_only">(</span>
+        <span class="screen_reader_only">&rpar;</span>
       </h2>
 
       <ul class="open_source_links">

--- a/packages/app/src/css/screen_reader_only.utility.css
+++ b/packages/app/src/css/screen_reader_only.utility.css
@@ -1,5 +1,5 @@
 .screen_reader_only {
   position: absolute;
-  visibility: hidden;
+  opacity: 0;
   pointer-events: none;
 }


### PR DESCRIPTION
- use opactity instead of visibility to actually enable screen-reader-only utility
- use html special characters for sr-only round brackets in footer
